### PR TITLE
fix: extend vm_memory validation for t-shirt sizes

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -106,8 +106,8 @@ variable "vm_memory" {
   description = "amount of memory of the vm"
   
   validation {
-    condition     = contains([1024, 2048, 4096, 8192], var.vm_memory)
-    error_message = "Valid values for vm_memory are (1024, 2048, 4096, 8192)"
+    condition     = contains([1024, 2048, 4096, 8192, 12288, 16384, 20480, 24576], var.vm_memory)
+    error_message = "Valid values for vm_memory are (1024, 2048, 4096, 8192, 12288, 16384, 20480, 24576)"
   }
 }
 


### PR DESCRIPTION
## Summary
- Extend vm_memory validation to include 12288, 16384, 20480, 24576 MB
- Supports large (16 GB) and xlarge (24 GB) t-shirt sizes used by Backstage template

## Test plan
- [ ] Verify `terraform validate` passes with new memory values

🤖 Generated with [Claude Code](https://claude.com/claude-code)