### PR TITLE
feat: add vm_vlan_tag support for network interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ output "ip" {
 | `vm_network_type` | string | `"virtio"` | Network card model |
 | `vm_network_address0` | string | `"ip=dhcp"` | IP config for cloud-init |
 | `vm_macaddr` | string | `null` | MAC address (optional) |
+| `vm_vlan_tag` | number | `-1` | VLAN tag for the NIC (e.g. on `vmbrvlan`); `-1` = untagged, valid `2`-`4094` |
 | `vm_ssh_user` | string | `""` | SSH username for provisioner |
 | `vm_ssh_password` | string | `""` | SSH password for provisioner |
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -60,6 +60,7 @@
 | `vm_network_type` | string | `"virtio"` | Network card model |
 | `vm_network_address0` | string | `"ip=dhcp"` | Cloud-init IP configuration |
 | `vm_macaddr` | string | `null` | MAC address (auto-generated if null) |
+| `vm_vlan_tag` | number | `-1` | VLAN tag for the NIC (e.g. on `vmbrvlan`). `-1` = untagged; valid `2`-`4094` |
 
 ## SSH Provisioner
 

--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "vm_memory" {
   default     = 4096
   type        = number
   description = "amount of memory of the vm"
-  
+
   validation {
     condition     = contains([1024, 2048, 4096, 8192, 12288, 16384, 20480, 24576], var.vm_memory)
     error_message = "Valid values for vm_memory are (1024, 2048, 4096, 8192, 12288, 16384, 20480, 24576)"
@@ -163,6 +163,17 @@ variable "vm_macaddr" {
   default     = null
   type        = string
   description = "Mac address of desired vm"
+}
+
+variable "vm_vlan_tag" {
+  default     = -1
+  type        = number
+  description = "VLAN tag for the network interface (e.g. on bridge vmbrvlan). Set to -1 for no VLAN tag (untagged)."
+
+  validation {
+    condition     = var.vm_vlan_tag == -1 || (var.vm_vlan_tag >= 2 && var.vm_vlan_tag <= 4094)
+    error_message = "Valid values for vm_vlan_tag are -1 (untagged) or 2-4094."
+  }
 }
 
 variable "pve_api_url" {

--- a/vm.tf
+++ b/vm.tf
@@ -1,6 +1,6 @@
 resource "proxmox_vm_qemu" "proxmox_vm" {
-  target_node = var.pve_cluster_node
-  pool        = var.pve_folder_path
+  target_node        = var.pve_cluster_node
+  pool               = var.pve_folder_path
   start_at_node_boot = var.vm_onboot
   count              = var.vm_count
   name               = count.index > 0 ? "${var.vm_name}-${count.index + 1}" : var.vm_name
@@ -31,6 +31,7 @@ resource "proxmox_vm_qemu" "proxmox_vm" {
     model   = var.vm_network_type
     bridge  = var.pve_network
     macaddr = var.vm_macaddr
+    tag     = var.vm_vlan_tag
   }
 
   lifecycle {


### PR DESCRIPTION
## What

Adds VLAN support to the module. Wires the `network` block's `tag` attribute to a new `vm_vlan_tag` variable, so VMs can be attached to a specific VLAN on a VLAN-aware bridge (e.g. `vmbrvlan`).

## Why

On the `ul-pve01`/`ul-pve02` cluster, `vmbrvlan` is a VLAN-aware trunk (allowed tags 2-4094). The networks `10.31.101.0/24`-`10.31.104.0/24` map to VLAN tags `101`-`104`. Until now the module had no way to set a VLAN tag, so those networks were unreachable via this module.

## Changes

- `vm.tf`: add `tag = var.vm_vlan_tag` to the `network` block
- `variables.tf`: new `vm_vlan_tag` variable (default `-1` = untagged; validation allows `-1` or `2`-`4094`)
- `README.md` / `docs/variables.md`: document the new variable

## Compatibility

Default `-1` keeps the existing untagged behaviour — no breaking change for existing configs.

## Test

CI green on the feature branch (validate / tflint / terraform-docs / trivy security).

🤖 Generated with [Claude Code](https://claude.com/claude-code)